### PR TITLE
Add Claude Code stop hook for quality checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'just check; s=$?; if [ $s -eq 2 ]; then exit 1; fi; exit $s'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "just check",
+            "blocking": false
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a project-level `.claude/settings.json` with a non-blocking `Stop` hook
- Runs `just check` (build + link check) after each Claude Code response
- No dev server required — operates on static build output

## Test plan
- [x] Verified `just check` runs successfully standalone (build + 848 links, 0 errors)
- [x] Validated JSON is well-formed
- [ ] Confirm hook fires after a Claude Code response (visible in `--verbose` mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)