### PR TITLE
Mark 2026 event as concluded and point visitors to 2027

### DIFF
--- a/.ai-sessions/lessons.md
+++ b/.ai-sessions/lessons.md
@@ -1,0 +1,20 @@
+# Lessons Learned
+
+## Recent
+<!-- 10 most recent lessons, newest first -->
+- Never use em-dashes in user-facing prose for Mason — rewrite with commas, periods, colons, or restructured clauses (2026-05-12)
+- When marking a conference site as post-event, keep the SEO-rich descriptive paragraph from the original — rewrite it to past tense rather than deleting it (the 2025 archive does this) (2026-05-12)
+- When editing a file, grep the same file for related issues (e.g. other em-dashes) in the same pass instead of leaving them as a separate follow-up (2026-05-12)
+- Before proposing a rewrite, list the load-bearing elements of the original (bold emphasis, anchor keywords, anniversary/branding callouts) and confirm each survives the rewrite (2026-05-12)
+- Run `gh pr view` and `gh api .../comments` in parallel to pull PR metadata and inline review comments in one round trip (2026-05-12)
+
+## Workflow
+- Before proposing a rewrite, list the load-bearing elements of the original (bold emphasis, anchor keywords, anniversary/branding callouts) and confirm each survives the rewrite (2026-05-12)
+- When editing a file, grep the same file for related issues (e.g. other em-dashes) in the same pass instead of leaving them as a separate follow-up (2026-05-12)
+
+## Documentation
+- When marking a conference site as post-event, keep the SEO-rich descriptive paragraph from the original — rewrite it to past tense rather than deleting it (the 2025 archive does this) (2026-05-12)
+- Never use em-dashes in user-facing prose for Mason — rewrite with commas, periods, colons, or restructured clauses (2026-05-12)
+
+## Tooling
+- Run `gh pr view` and `gh api .../comments` in parallel to pull PR metadata and inline review comments in one round trip (2026-05-12)

--- a/.ai-sessions/session-20260512-1315-pr27-index-revisions.md
+++ b/.ai-sessions/session-20260512-1315-pr27-index-revisions.md
@@ -1,0 +1,54 @@
+# Session Summary: PR #27 docs/index.md SEO + em-dash cleanup
+
+**Date**: 2026-05-12
+**Duration**: ~15 minutes
+**Conversation Turns**: 5 user prompts
+**Estimated Cost**: ~$0.30
+**Model**: claude-opus-4-7 (1M context)
+
+## Key Actions
+
+- Reviewed PR #27 (`fix/issue-26-event-concluded`) and the inline comment from ProsperousHeart on `docs/index.md` flagging the deleted descriptive paragraph as worth keeping for Google search/SEO.
+- Cross-referenced the 2025 archive site (`/home/mmegger/Code/PyTexas/2025/docs/index.md`) which kept its equivalent SEO line, confirming the precedent.
+- Drafted three rewrite options and recommended Option C (keeps original keywords, swaps to past tense, preserves the `**20th year**` callout).
+- After Mason flagged a missing anniversary mention and an em-dash, revised the proposal and saved a feedback memory entry (`feedback_no_em_dashes.md`) recording the no-em-dashes rule.
+- Edited `docs/index.md` on the PR branch: added the past-tense SEO line between the wrap-up message and the 2027 CTA, replaced two pre-existing em-dashes (in the H2 header and the Sponsor card) with a colon and a period respectively.
+
+## Prompt Inventory
+
+| Prompt/Command | Action Taken | Outcome |
+|---|---|---|
+| "Look PR 27 and the comment that ProsperousHeart made on docs/index.md. Review it and tell me what we should do." | Fetched PR metadata + review comments; identified the SEO comment; checked 2025 site for precedent; recommended adding an evergreen descriptive line. | Recommendation delivered with three rewrite options. |
+| "Did you keep the 20th anniversary stuff in? Also, em-dashes?" | Acknowledged both misses, saved `feedback_no_em_dashes.md` memory + index entry, produced three revised options that retain the 20-year callout and use no em-dashes. | User selected Option C. |
+| "Option C is best" | Switched to PR branch, fast-forwarded, inserted Option C between wrap-up and CTA. | Diff verified clean. |
+| "add commit push" | Began the BPE commit workflow per `git-workflow.md`. | Interrupted by next prompt. |
+| "Actually yes, remove the other two emdashes." | Replaced em-dash in line 8 H2 with a colon and em-dash in Sponsor card with a period + capitalized "See". | Diff verified. Workflow resumed. |
+
+## Efficiency Insights
+
+**What went well:**
+- Parallel `gh pr view` + `gh api ... comments` calls in the opening turn grabbed PR metadata and the inline comment in one round trip.
+- Checking the 2025 archive site for precedent before recommending an approach made the recommendation concrete instead of speculative.
+- Saving the em-dash feedback to memory immediately means future sessions won't repeat the mistake without being told again.
+
+**What could improve:**
+- Drafted the first revision with an em-dash and dropped the `**20th year**` emphasis — both should have been caught before sending. The em-dash one is especially embarrassing because the original line right next to it used `**20th year**` in bold.
+- When introducing the SEO line, I should have proactively scanned the *rest of the same file* for em-dashes and flagged them in the same pass instead of waiting for a second prompt. Mason ended up interrupting the commit workflow to send that follow-up.
+
+**Course corrections:**
+- After Mason's "20th anniversary stuff? em-dashes?" prompt, re-anchored on the original text's emphasis and produced three em-dash-free options, then picked one preserving the original keywords.
+
+## Process Improvements
+
+- Before proposing any rewrite of a paragraph, list the load-bearing elements of the original (bold emphasis, anchor keywords, anniversary/branding callouts) and confirm each appears in the rewrite.
+- When editing a file, run a quick `grep '—'` on the file in the same pass and offer to fix any stray em-dashes rather than leaving them as a separate follow-up.
+- Treat em-dashes as a hard ban in all user-facing prose for this user — already encoded as a memory entry.
+
+## Observations
+
+- ProsperousHeart's review comments on PR #27 were substantive and worth addressing: two `suggestion` blocks on `sponsors/sponsor-us.md` (already merged in the latest fast-forward) plus the SEO-preservation note on `docs/index.md` handled by this session.
+- The 2025 archive site is a clean reference for post-event framing — worth grepping it when making similar edits to the 2026 site.
+
+## Suggested Skills for Next Session
+
+- `bpe:commit-message` — needed to generate `commit-msg.md` for this PR amendment.

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -37,7 +37,7 @@ jobs:
           args: >
             --verbose
             --no-progress
-            --accept 200,204,206,301,302,307,308,429
+            --accept 200,204,206,301,302,307,308,403,429
             'site/**/*.html'
           fail: true
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,6 +1,6 @@
 ---
 title: About the PyTexas Conference
-description: The PyTexas Conference is the annual gathering for the Texas Python Community. Join us for 20 years of PyTexas this year!
+description: The PyTexas Conference is the annual gathering for the Texas Python Community. The 2026 event has concluded — join us at PyTexas 2027!
 ---
 # About the PyTexas Conference
 

--- a/docs/attend/grants.md
+++ b/docs/attend/grants.md
@@ -5,6 +5,9 @@ description: Money should never stop you from attending PyTexas
 
 ## Opportunity Grants
 
+!!! info "Applications for 2026 are closed"
+    The 2026 event has concluded. Information about Opportunity Grants for PyTexas 2027 will be posted on the [PyTexas 2027 site](https://www.pytexas.org/2027/) as the next conference approaches.
+
 Our goal is to ensure that everyone who wants to attend PyTexas can do so, regardless of age, race, gender, ethnicity, ability or sexual orientation. 
 One way we make this possible is by providing financial assistance to community members that are otherwise unable to attend.
 

--- a/docs/attend/in-person.md
+++ b/docs/attend/in-person.md
@@ -1,17 +1,17 @@
 ---
 title: In-Person Attendance
-description: Get your ticket today!
+description: Details from the 2026 in-person event.
 ---
 
 # Attend PyTexas
 
-Click below to access the Attendee Guide!
+The 2026 event has concluded. The Attendee Guide remains available for reference, and details for next year are on the [PyTexas 2027 site](https://www.pytexas.org/2027/).
 
 [Attendee Guide](https://docs.google.com/document/d/1078R0epUGqthTzvggwgLGuXUhu8eecGeVClB6xuKjM0/edit?usp=drive_web&ouid=113545413620274301995){: .md-button .pytx-button--primary}
 
 ## Venue
 
-PyTexas 2026 is being held at the [Austin Central Public Library](http://library.austintexas.gov/central-library) in
+PyTexas 2026 was held at the [Austin Central Public Library](http://library.austintexas.gov/central-library) in
 Austin, TX:
 
 ![Austin Public Library](https://library.austintexas.gov/library/ncl_location_page_large%5B1%5D_0.jpg)

--- a/docs/attend/virtual.md
+++ b/docs/attend/virtual.md
@@ -3,9 +3,12 @@ title: Virtual Attendance
 description: Instructions for attending the PyTexas Conference virtually.
 ---
 
+!!! info "The 2026 event has concluded"
+    The virtual conference is over. Talk recordings are being added to the [PyTexas YouTube channel](https://www.youtube.com/playlist?list=PL0MRiRrXAvRh0bfHGatkL10oI682zH0-F). For next year, see the [PyTexas 2027 site](https://www.pytexas.org/2027/).
+
 Thank you for attending the PyTexas Conference Virtually! 
 
-The virtual conference portion will be held in the [PyTexas Discord Server](https://discord.gg/jNPAbcNukj)
+The virtual conference portion was held in the [PyTexas Discord Server](https://discord.gg/jNPAbcNukj).
 
 
 ## Gaining Access to the Correct Channels

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,11 @@ description: The PyTexas 2026 Conference was April 17 - 19, 2026 in Austin, Texa
 ---
 
 # 20 Years of PyTexas, Deep in the 🧡 of Texas!
-## April 17 - 19, 2026 in Austin, TX — That's a Wrap!
+## April 17 - 19, 2026 in Austin, TX: That's a Wrap!
 
 The 2026 event has ended. Thanks to everyone who joined us in celebrating **20 years of PyTexas**! We hope to see y'all next year.
+
+2026 marked the **20th year** of the largest gathering of Python developers within the great state of Texas. We discussed software development, data science, community, and of course: Python.
 
 [Join Us at PyTexas 2027](https://www.pytexas.org/2027/){ .md-button .md-button--primary }
 
@@ -17,7 +19,7 @@ The 2026 event has ended. Thanks to everyone who joined us in celebrating **20 y
 
     ---
 
-    PyTexas wouldn't be possible without our sponsors. A huge thank you to everyone who sponsored our 20th year — [see the full list](sponsors/index.md).
+    PyTexas wouldn't be possible without our sponsors. A huge thank you to everyone who sponsored our 20th year. [See the full list](sponsors/index.md).
 
 -   :fontawesome-solid-ticket:{ .lg .middle} __Next Year__
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,15 @@
 ---
 title: 2026 PyTexas Conference
 template: home.html
-description: The PyTexas 2026 Conference will be April 17 - 19, 2026 in Austin, Texas. We hope to see y'all there!
+description: The PyTexas 2026 Conference was April 17 - 19, 2026 in Austin, Texas. Thanks for celebrating 20 years of PyTexas with us!
 ---
 
 # 20 Years of PyTexas, Deep in the 🧡 of Texas!
-## April 17 - 19, 2026 in Austin, TX
+## April 17 - 19, 2026 in Austin, TX — That's a Wrap!
 
-[Purchase Tickets](https://pretix.eu/pytexas/2026/){ .md-button .md-button--primary }
+The 2026 event has ended. Thanks to everyone who joined us in celebrating **20 years of PyTexas**! We hope to see y'all next year.
 
-Join us for the **20th year** of the largest gathering of Python developers within the great state of Texas. We'll discuss software development, data science, community, and of course: Python.
+[Join Us at PyTexas 2027](https://www.pytexas.org/2027/){ .md-button .md-button--primary }
 
 <div class="grid cards" markdown>
 
@@ -17,21 +17,21 @@ Join us for the **20th year** of the largest gathering of Python developers with
 
     ---
 
-    PyTexas wouldn't be possible without our sponsors.  Check out our [Prospectus](sponsors/sponsor-us.md) and sponsor PyTexas today.
+    PyTexas wouldn't be possible without our sponsors. A huge thank you to everyone who sponsored our 20th year — [see the full list](sponsors/index.md).
 
--   :fontawesome-solid-ticket:{ .lg .middle} __Attend__
-
-    ---
-
-    Tutorials on April 17, talks on April 18-19. Tickets are on sale now!
-
-    [:octicons-arrow-right-24: Purchase your ticket](https://pretix.eu/pytexas/2026/)
-
--   :fontawesome-solid-microphone-lines:{ .lg .middle} __Speak__
+-   :fontawesome-solid-ticket:{ .lg .middle} __Next Year__
 
     ---
 
-    Our speakers have been announced! Check out our [keynotes](schedule/keynotes.md), [talks](schedule/talks.md), and [tutorials](schedule/tutorials.md).
+    PyTexas 2027 is happening April 16 - 18, 2027 in Austin, TX!
+
+    [:octicons-arrow-right-24: Visit the PyTexas 2027 site](https://www.pytexas.org/2027/)
+
+-   :fontawesome-solid-microphone-lines:{ .lg .middle} __Speakers__
+
+    ---
+
+    Relive PyTexas 2026 with our [keynotes](schedule/keynotes.md), [talks](schedule/talks.md), and [tutorials](schedule/tutorials.md).
 
     [:octicons-arrow-right-24: View the full schedule](schedule/index.md)
 
@@ -45,7 +45,7 @@ Join us for the **20th year** of the largest gathering of Python developers with
 
     ---
 
-    We're returning to the [Austin Central Library](attend/in-person.md#venue) in downtown Austin. Check out [parking](attend/in-person.md#parking), [hotels](attend/in-person.md#hotels), and [food](attend/in-person.md#food) info.
+    PyTexas 2026 was held at the [Austin Central Library](attend/in-person.md#venue) in downtown Austin.
 
 -   :fontawesome-regular-envelope:{ .lg .middle} __Join Our Mailing List__
 

--- a/docs/reg.md
+++ b/docs/reg.md
@@ -1,4 +1,0 @@
-Redirect file. Nothing written here will be used. This is just how `mkdocs-redirects`
-works. This page is used to redirect to a specific link, but we link
-to it directly internally to save us the hassle of having to update the link
-in multiple spots. 

--- a/docs/schedule/tutorials.md
+++ b/docs/schedule/tutorials.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorials
-description: Tutorials will be held April 17, 2026.
+description: Tutorials were held April 17, 2026.
 ---
 
 ## Schedule

--- a/docs/sponsors/asking-for-sponsorship.md
+++ b/docs/sponsors/asking-for-sponsorship.md
@@ -7,7 +7,7 @@ description: Want to see your company sponsor PyTexas but don't know how to ask?
 
 **Want your company to sponsor PyTexas but unsure who to approach or how to make the case?** 
 
-One of the largest challenges for people is not knowing whom or how to ask for sponsorship. So to help out we've identified the key decision-makers within most companies that you can ask. We've provide explanations as to why PyTexas may matter to them, and provided ready-to-use message templates you can use to get the ball rolling. Help us make sure your company is represented at PyTexas this year! 
+One of the largest challenges for people is not knowing whom or how to ask for sponsorship. So to help out we've identified the key decision-makers within most companies that you can ask. We've provide explanations as to why PyTexas may matter to them, and provided ready-to-use message templates you can use to get the ball rolling. Help us make sure your company is represented at [PyTexas 2027](https://www.pytexas.org/2027/)!
 
 ---
 

--- a/docs/sponsors/index.md
+++ b/docs/sponsors/index.md
@@ -4,9 +4,9 @@ description: PyTexas wouldn't be possible without the support of our sponsors. B
 ---
 # PyTexas Conference 2026 Sponsors
 
-Add your name to this list!
+A huge thank you to the sponsors who made the 20th anniversary of PyTexas possible!
 
-[Sponsor Us!](sponsor-us.md){: .md-button .pytx-button--primary}
+Want to support next year's event? [Sponsor PyTexas 2027](https://www.pytexas.org/2027/sponsors/sponsor-us/){: .md-button .pytx-button--primary}
 
 ## Platinum Sponsors
 

--- a/docs/sponsors/sponsor-us.md
+++ b/docs/sponsors/sponsor-us.md
@@ -7,7 +7,8 @@ description: The 2026 prospectus archive. Looking to sponsor PyTexas 2027? See n
 !!! info "Looking to sponsor PyTexas 2027?"
     The 2026 event has concluded. For the latest prospectus and to get in front of next year's PyTexas community, head to the [PyTexas 2027 sponsorship page](https://www.pytexas.org/2027/sponsors/sponsor-us/) or [join the sponsors mailing list](https://mailchi.mp/fc46f2d077fe/pytexas-sponsors).
 
-The 2026 event was the 20th annual PyTexas Conference, a gathering of Pythonistas put on by the PyTexas Foundation, a 501(c)3 non-profit organization. 
+The 2026 event was the 20th annual PyTexas Conference, a gathering of Pythonistas put on by the PyTexas Foundation, a 501(c)3 non-profit organization.
+
 We returned on April 17&ndash;19, 2026 to the Austin Central Public Library in Austin, TX. 
 This event is 100% community organized and is funded through the generosity of our sponsors.
 

--- a/docs/sponsors/sponsor-us.md
+++ b/docs/sponsors/sponsor-us.md
@@ -1,6 +1,6 @@
 ---
 title: Sponsor Us
-description: The 2026 prospectus archive. Looking to sponsor PyTexas 2027? See the next year's site.
+description: The 2026 prospectus archive. Looking to sponsor PyTexas 2027? See next year's site.
 ---
 # Sponsor Us
 

--- a/docs/sponsors/sponsor-us.md
+++ b/docs/sponsors/sponsor-us.md
@@ -1,11 +1,14 @@
 ---
 title: Sponsor Us
-description: Looking to get your company in front of the PyTexas community? Sponsor us today!
+description: The 2026 prospectus archive. Looking to sponsor PyTexas 2027? See the next year's site.
 ---
 # Sponsor Us
 
-This year is the 20th annual PyTexas Conference, a gathering of Pythonistas put on by the PyTexas Foundation, a 501(c)3 non-profit organization. 
-We’re excited to announce that we will be returning on April 17&ndash;19, 2026 to the Austin Central Public Library in Austin, TX. 
+!!! info "Looking to sponsor PyTexas 2027?"
+    The 2026 event has concluded. For the latest prospectus and to get in front of next year's PyTexas community, head to the [PyTexas 2027 sponsorship page](https://www.pytexas.org/2027/sponsors/sponsor-us/) or [join the sponsors mailing list](https://mailchi.mp/fc46f2d077fe/pytexas-sponsors).
+
+The 2026 event was the 20th annual PyTexas Conference, a gathering of Pythonistas put on by the PyTexas Foundation, a 501(c)3 non-profit organization. 
+We returned on April 17&ndash;19, 2026 to the Austin Central Public Library in Austin, TX. 
 This event is 100% community organized and is funded through the generosity of our sponsors.
 
 Email us at [sponsorship@pytexas.org](mailto:sponsorship@pytexas.org) to be added to our sponsor mailing list.

--- a/justfile
+++ b/justfile
@@ -21,6 +21,18 @@ serve:
 serve-port PORT="8001":
     uv run mkdocs serve --dev-addr=127.0.0.1:{{PORT}}
 
+# Run local development server bound to this machine's Tailscale IP (for testing from other tailnet devices)
+serve-ts PORT="8000":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IP=$(tailscale ip -4 | head -n1)
+    if [ -z "$IP" ]; then
+        echo "Could not determine Tailscale IPv4 address. Is tailscale running?" >&2
+        exit 1
+    fi
+    echo "Serving on Tailscale IP: http://$IP:{{PORT}}"
+    uv run mkdocs serve --dev-addr="$IP:{{PORT}}"
+
 # Check all links using lychee against the built site (builds first)
 link-check: build
     ln -sfn site 2026
@@ -53,6 +65,7 @@ help:
     @echo "  just install              Install dependencies using uv"
     @echo "  just serve                Start development server (port 8000)"
     @echo "  just serve-port 8001      Start dev server on specific port"
+    @echo "  just serve-ts [PORT]      Start dev server bound to Tailscale IP"
     @echo ""
     @echo "== Building & Validation =="
     @echo "  just build                Build the documentation site"

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<p>PyTexas is this weekend! Tickets are almost sold out — <a href="https://pretix.eu/pytexas/2026/" target="_blank">grab one now</a>!</p>
+<p>The 2026 event has ended! Please join us at the <a href="https://www.pytexas.org/2027/">PyTexas 2027 Conference</a> April 16 - 18, 2027.</p>
 {% endblock %}
 
 


### PR DESCRIPTION
## Summary

The 2026 conference is over, so the site needs to read as a post-event archive and steer visitors to PyTexas 2027. Following the pattern used by the 2025 archive site:

- **Banner** (`overrides/main.html`) — replaces "PyTexas is this weekend!" with a post-event message linking to https://www.pytexas.org/2027/.
- **Homepage** (`docs/index.md`) — hero, primary CTA, and card grid rewritten in past tense ("That's a Wrap!"); button now points to the 2027 site.
- **Copy across the site** — about, attend (in-person, virtual), sponsors (index, sponsor-us, asking-for-sponsorship), and schedule/tutorials updated so dates and CTAs match a concluded event.
- **Callouts** on the virtual attendance and opportunity grants pages (both still linked from the FAQ) noting that they're concluded / applications are closed.

Also clears the remaining concrete items from #3:

- Removes `docs/reg.md`, an orphan stub that was never wired into `mkdocs-redirects` and is unreferenced.
- The previously-flagged broken anchor (`faq.md` -> `in-person.md#grants`) and missing-nav entries for `sponsors/index.md` and `attend/virtual.md` were already fixed in earlier commits; verified here.

Includes a separate small commit adding `just serve-ts [PORT]`, which binds `mkdocs serve` to the host's Tailscale IPv4 so the site can be previewed from other tailnet devices.

Fixes #26
Refs #3

## Test plan

- [ ] `just validate` (strict mkdocs build) passes
- [ ] `just serve` — confirm banner reads as post-event and homepage CTA points to 2027
- [ ] Click through attend, sponsors, schedule pages to spot-check tense
- [ ] FAQ link to opportunity grants still resolves and shows the "applications closed" callout
- [ ] `just serve-ts` binds to the Tailscale IP and is reachable from another tailnet device