### PR TITLE
Embed YouTube recordings on talks and keynotes pages

### DIFF
--- a/.ai-sessions/lessons.md
+++ b/.ai-sessions/lessons.md
@@ -1,0 +1,30 @@
+# Lessons Learned
+
+## Recent
+<!-- 10 most recent lessons, newest first -->
+- A `[text](url1 url2)` typo in markdown survives local preview but lychee URL-encodes the space to `%20` and reports a single 404. Run `just link-check` before pushing schedule/talks edits (2026-05-12)
+- When one instance of a service fails link-check but other instances of the same service pass on the same branch, it's targeted rate-limiting. Prefer a single-URL `.lycheeignore` entry over a wildcard (2026-05-12)
+- For failing GH Actions logs, `gh api repos/{owner}/{repo}/actions/jobs/{id}/logs` is more reliable than `gh run view --log`, which can return empty (2026-05-12)
+- Before removing a URL from a markdown link target, verify the URL is linked elsewhere on the page so no info is lost (2026-05-12)
+- Never use em-dashes in user-facing prose for Mason. Rewrite with commas, periods, colons, or restructured clauses (2026-05-12)
+- When marking a conference site as post-event, keep the SEO-rich descriptive paragraph from the original. Rewrite it to past tense rather than deleting it (the 2025 archive does this) (2026-05-12)
+- When editing a file, grep the same file for related issues (e.g. other em-dashes) in the same pass instead of leaving them as a separate follow-up (2026-05-12)
+- Before proposing a rewrite, list the load-bearing elements of the original (bold emphasis, anchor keywords, anniversary/branding callouts) and confirm each survives the rewrite (2026-05-12)
+- Run `gh pr view` and `gh api .../comments` in parallel to pull PR metadata and inline review comments in one round trip (2026-05-12)
+
+## Workflow
+- Before proposing a rewrite, list the load-bearing elements of the original (bold emphasis, anchor keywords, anniversary/branding callouts) and confirm each survives the rewrite (2026-05-12)
+- When editing a file, grep the same file for related issues (e.g. other em-dashes) in the same pass instead of leaving them as a separate follow-up (2026-05-12)
+- Before removing a URL from a markdown link target, verify the URL is linked elsewhere on the page so no info is lost (2026-05-12)
+
+## Documentation
+- When marking a conference site as post-event, keep the SEO-rich descriptive paragraph from the original. Rewrite it to past tense rather than deleting it (the 2025 archive does this) (2026-05-12)
+- Never use em-dashes in user-facing prose for Mason. Rewrite with commas, periods, colons, or restructured clauses (2026-05-12)
+
+## Tooling
+- Run `gh pr view` and `gh api .../comments` in parallel to pull PR metadata and inline review comments in one round trip (2026-05-12)
+- For failing GH Actions logs, `gh api repos/{owner}/{repo}/actions/jobs/{id}/logs` is more reliable than `gh run view --log`, which can return empty (2026-05-12)
+
+## Debugging
+- A `[text](url1 url2)` typo in markdown survives local preview but lychee URL-encodes the space to `%20` and reports a single 404. Run `just link-check` before pushing schedule/talks edits (2026-05-12)
+- When one instance of a service fails link-check but other instances of the same service pass on the same branch, it's targeted rate-limiting. Prefer a single-URL `.lycheeignore` entry over a wildcard (2026-05-12)

--- a/.ai-sessions/session-20260512-1328-pr28-link-fixes.md
+++ b/.ai-sessions/session-20260512-1328-pr28-link-fixes.md
@@ -1,0 +1,53 @@
+# Session Summary: PR #28 link-check fixes
+
+**Date**: 2026-05-12
+**Duration**: ~10 minutes
+**Conversation Turns**: 3 user prompts
+**Estimated Cost**: ~$0.20
+**Model**: claude-opus-4-7 (1M context)
+
+## Key Actions
+
+- Inspected PR #28 (`add/youtube-video-embeds`) link-check failure via `gh pr checks 28` and pulled raw job logs through `gh api repos/pytexas/2026/actions/jobs/{id}/logs` (the `gh run view --log` shortcut returned empty for this run).
+- Identified two distinct failures from the lychee report:
+  1. `docs/schedule/talks.md:47`: `[Repo](...)` markdown link target contained two URLs glued together with a space, which lychee URL-encoded into `%20` and treated as one 404 URL.
+  2. `docs/schedule/talks.md:223`: Indrasena Manga's LinkedIn profile (`https://www.linkedin.com/in/indra7979/`) returning 404 to GitHub runner. Confirmed it was the only failing LinkedIn `/in/` URL on the branch (avik-basu and kkeeton both passed), and Mason verified the slug is correct, so LinkedIn is rate-limiting that specific runner request.
+- On the `add/youtube-video-embeds` branch:
+  - Stripped the trailing Pulumi URL out of the `[Repo]` target in `docs/schedule/talks.md` (Pulumi URL was already linked separately on the next bullet as `[site]`, so no information lost).
+  - Appended `https://www.linkedin.com/in/indra7979/` to `.lycheeignore` since Mason confirmed the URL is valid and the failure is anti-bot blocking the runner IP.
+
+## Prompt Inventory
+
+| Prompt/Command | Action Taken | Outcome |
+|---|---|---|
+| "Now look at PR 28 and see why those links are breaking in the CI" | Pulled job logs, located the two errors in lychee output, diffed PR branch to confirm both links were new on the branch, distinguished LinkedIn rate-limiting from real 404 by comparing against other `/in/` URLs on the same branch. | Diagnosis delivered with three fix options for the LinkedIn link. |
+| "Here's indra's linkedin https://www.linkedin.com/in/indra7979/ and fix the typo" | Switched to `add/youtube-video-embeds`, fast-forwarded to remote, edited `docs/schedule/talks.md:47` to drop the extra URL, and added the indra7979 URL to `.lycheeignore`. | Diffs verified clean. Ready to commit. |
+| "(implicit) commit and push" | Triggered BPE commit workflow per `git-workflow.md`. | In progress. |
+
+## Efficiency Insights
+
+**What went well:**
+- `gh pr checks 28` and `gh api .../jobs/.../logs` got the failing output without needing to open the GitHub web UI.
+- Cross-checking the failing LinkedIn URL against the *other* LinkedIn `/in/` URLs on the same branch (`avik-basu`, `kkeeton`) avoided a wrong "LinkedIn blocks all runners" conclusion and let me present a more accurate diagnosis.
+- The Adam Gordon Bell fix was clean because the Pulumi URL was already linked elsewhere. Verified that before recommending the removal.
+
+**What could improve:**
+- First attempt at `gh run view --log` returned empty output, wasted a tool call before falling back to the raw `gh api .../jobs/.../logs` endpoint. Worth remembering for next time.
+
+**Course corrections:**
+- Initially leaned toward "verify the LinkedIn slug" as the preferred fix, but Mason had pretalx/speaker confirmation and accepted the `.lycheeignore` route since the URL is correct. Adjusted to that path immediately rather than pushing for the verification I'd already recommended.
+
+## Process Improvements
+
+- When debugging failing GH Actions runs, skip `gh run view --log` and go directly to `gh api repos/{owner}/{repo}/actions/jobs/{id}/logs`. It returns the full log reliably.
+- When a single instance of a service (LinkedIn, Twitter, etc.) fails link-check but other instances on the same branch pass, prefer the targeted `.lycheeignore` entry over a wildcard. Wildcards mask real future breakage; a single-URL ignore is auditable.
+- Before stripping a URL from a markdown link target, confirm the URL is reachable elsewhere on the page so no real information is lost.
+
+## Observations
+
+- The `[Repo](url1 url2)` typo is the kind of thing markdown won't flag locally. Only lychee catches it in CI. Reinforces that the `just check` / `just link-check` step is worth running pre-push for talks/schedule edits.
+- `.lycheeignore` already had a small set of entries (g.page wildcard, Bloomberg, localhost). Adding individual URLs there is the established pattern on this repo.
+
+## Suggested Skills for Next Session
+
+- `bpe:commit-message`: needed to generate `commit-msg.md` for this fix commit.

--- a/.ai-sessions/session-20260512-1340-pr28-linkedin-broaden.md
+++ b/.ai-sessions/session-20260512-1340-pr28-linkedin-broaden.md
@@ -1,0 +1,45 @@
+# Session Summary: PR #28 broaden LinkedIn ignore
+
+**Date**: 2026-05-12
+**Duration**: ~2 minutes
+**Conversation Turns**: 1 user prompt
+**Estimated Cost**: ~$0.05
+**Model**: claude-opus-4-7 (1M context)
+
+## Key Actions
+
+- Re-ran link-check after merging `main` into `add/youtube-video-embeds` and resolving the `.ai-sessions/lessons.md` conflict. Link-check still failed.
+- Mason reported LinkedIn 404s flip intermittently across different `/in/` profiles (not just `indra7979`), invalidating the earlier "targeted single-URL ignore" diagnosis.
+- Grepped `docs/` for all LinkedIn URLs in use (`avik-basu`, `indra7979`, `kkeeton`, all under `www.linkedin.com/in/`).
+- Replaced the single-URL `.lycheeignore` entry with `https://www.linkedin.com/`, which covers every LinkedIn URL the site references today.
+
+## Prompt Inventory
+
+| Prompt/Command | Action Taken | Outcome |
+|---|---|---|
+| "It failed. It seems like linkedin just randomly stops working and returning a 404. Just add a blanket ignore for linkedin" | Confirmed all LinkedIn URLs in `docs/` are under `www.linkedin.com/`, replaced the targeted ignore with a blanket prefix. | One-line `.lycheeignore` edit, ready to commit. |
+
+## Efficiency Insights
+
+**What went well:**
+- Verified the LinkedIn URL surface across `docs/` before broadening so the new pattern is known to cover every existing case rather than being a guess.
+
+**What could improve:**
+- The previous commit recommended a targeted ignore based on one observed run. A second run showing different LinkedIn URLs failing would have caught the flakiness sooner. For unstable third-party domains, default to broader ignores after the first failure rather than chasing individual URLs.
+
+**Course corrections:**
+- Reversed the earlier "single-URL is more auditable than a wildcard" stance for LinkedIn specifically. The previous commit message frames it as targeted on purpose; this commit's message explains why we broadened.
+
+## Process Improvements
+
+- For domains with well-known anti-bot behavior (LinkedIn, Twitter/X, Facebook), default to a blanket `.lycheeignore` entry the first time one fails rather than chasing per-URL ignores.
+- After resolving a merge conflict during a CI fix cycle, expect CI to need at least one more iteration. Pipe enough time between iterations to watch the result rather than firing off another commit immediately.
+
+## Observations
+
+- The `.lycheeignore` patterns in this repo (`g.page/*`, `bloomberg.com`, etc.) match anywhere in the URL, so `https://www.linkedin.com/` covers all paths beneath it without needing a trailing wildcard.
+- The pre-commit hook requires a new `.ai-sessions/` file even for trivial follow-up commits. Worth a future hook tweak if Mason wants to allow follow-ups to ride on the previous session summary.
+
+## Suggested Skills for Next Session
+
+- None.

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -37,7 +37,7 @@ jobs:
           args: >
             --verbose
             --no-progress
-            --accept 200,204,206,301,302,307,308,429
+            --accept 200,204,206,301,302,307,308,403,429
             'site/**/*.html'
           fail: true
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,3 +2,4 @@ localhost:8000
 https://g.page/*
 https://www.bloomberg.com
 https://www.bloomberg.com/company/values/tech-at-bloomberg/
+https://www.linkedin.com/in/indra7979/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,4 +2,4 @@ localhost:8000
 https://g.page/*
 https://www.bloomberg.com
 https://www.bloomberg.com/company/values/tech-at-bloomberg/
-https://www.linkedin.com/in/indra7979/
+https://www.linkedin.com/

--- a/docs/schedule/keynotes.md
+++ b/docs/schedule/keynotes.md
@@ -3,9 +3,17 @@ title: Keynote Speakers
 description: We are proud to have Dawn Wages and Hynek Schlawack join us to deliver the 2026 keynotes.
 ---
 
+<div class="keynote-card" markdown="1">
+
 ## Dawn Wages
 
-![Dawn Wages](../assets/images/speakers/dawn-wages.jpg){: width="300" align=left}
+<div class="keynote-middle" markdown="1">
+<div markdown="1">
+
+![Dawn Wages](../assets/images/speakers/dawn-wages.jpg){: width="300"}
+
+</div>
+<div markdown="1">
 
 Dawn Wages is the Director of Community and Developer Relations at Anaconda,
 responsible for the most popular Python distribution in the world.
@@ -17,18 +25,43 @@ combining technical knowledge with attention to equity, sovereignty, and develop
 
 When not working on Python, she enjoys watching Star Trek in Philadelphia with her wife and two dogs.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/mHG3aAkbpvA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+</div>
 
-<br clear=all>
+<div class="video-wrapper">
+<!-- <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/mHG3aAkbpvA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe> -->
+<iframe src="https://www.youtube-nocookie.com/embed/mHG3aAkbpvA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+You can view the slides [here](https://dawnwages.info/pytexas-keynote-26/){target="_blank" rel="noopener"}.
+</div>
+
+<div class="keynote-card" markdown="1">
 
 ## Hynek Schlawack
 
-![Hynek Schlawack](../assets/images/speakers/hynek.jpeg){: width="300" align=left}
+<div class="keynote-middle" markdown="1">
+<div markdown="1">
+
+![Hynek Schlawack](../assets/images/speakers/hynek.jpeg){: width="300"}
+
+</div>
+<div markdown="1">
 
 Hynek Schlawack is a lead infrastructure and software engineer from Berlin, Germany,
 PSF fellow, blogger, YouTuber, and maintainer of *way* too many open source projects.
 His main areas of interest are networks, security, and robust software.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/MDqQTtjbVX8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+</div>
 
-<br clear=all>
+<div class="video-wrapper">
+<!-- <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/MDqQTtjbVX8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe> -->
+<iframe src="https://www.youtube-nocookie.com/embed/MDqQTtjbVX8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+You can view the slides [here](https://hynek.me/talks/design-pressure/){target="_blank" rel="noopener"}. Additional sites provided:
+
+- [ox.cx/design](http://ox.cx/design){target="_blank" rel="noopener"}
+- [vrmd.de](http://vrmd.de){target="_blank" rel="noopener"}
+- [hynek.me](http://hynek.me){target="_blank" rel="noopener"}
+- [youtube.com/@THE_HYNEK](http://youtube.com/@THE_HYNEK){target="_blank" rel="noopener"}
+</div>

--- a/docs/schedule/keynotes.md
+++ b/docs/schedule/keynotes.md
@@ -17,7 +17,9 @@ combining technical knowledge with attention to equity, sovereignty, and develop
 
 When not working on Python, she enjoys watching Star Trek in Philadelphia with her wife and two dogs.
 
-<br>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/mHG3aAkbpvA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+<br clear=all>
 
 ## Hynek Schlawack
 
@@ -27,4 +29,6 @@ Hynek Schlawack is a lead infrastructure and software engineer from Berlin, Germ
 PSF fellow, blogger, YouTuber, and maintainer of *way* too many open source projects.
 His main areas of interest are networks, security, and robust software.
 
-<br>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/MDqQTtjbVX8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+<br clear=all>

--- a/docs/schedule/talks.md
+++ b/docs/schedule/talks.md
@@ -11,6 +11,8 @@ Python's flexibility makes it an excellent choice for creating Domain-Specific L
 
 In this talk, we'll explore the art and science of designing Python DSLs that don't fight against the language's principles. You'll learn when to embrace Python's "magic" and when it becomes harmful, how to create APIs that feel pythonic even when they're domain-specific, and practical techniques for building DSLs through detailed analysis of successful real-world examples.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/K3JL5C8HFqo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Moshe Zadka**
 
 ![Moshe Zadka Headshot](https://pretalx.com/media/avatars/KYYQVJ_v0LCIik.webp){: width="150" align=left}
@@ -22,6 +24,8 @@ _Moshe has been a DevOps/SRE since before those terms existed, caring deeply abo
 ## I Built an AI Running Coach (That Actually Remembers My Training)
 
 Generic fitness apps don't know when you're sick, stressed, or injured. In this talk, I'll show how I built a personal AI running coach using Python. You'll learn how to reverse-engineer undocumented APIs (like Peloton), handle conflicting data, and use async serverless patterns to give LLMs "memory" and context.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/EfIbH20J97Q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Speaker: Adam Gordon Bell**
 
@@ -39,6 +43,8 @@ The Model Context Protocol (MCP) offers a structured way to expose Python tools 
 
 We will show how to apply schema validation, introduce simple sandboxing rules, and log tool usage for transparency. The goal is to provide practical patterns that help developers build LLM-powered features in Python with more confidence and oversight.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/rYPl3Tp978Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Maria Silvia Mielniczuk**
 
 ![Maria Silvia Mielniczuk Headshot](../assets/images/speakers/Maria_Silvia_Mielniczuk.png){: width="150" align=left}
@@ -51,6 +57,8 @@ _Maria Silvia Mielniczuk is a data scientist with a Master of Applied Data Scien
 
 With over 150 open-source visualization tools in the Python ecosystem, picking the right one can feel like choosing a restaurant in a city you've never visited - overwhelming, and with real consequences if you get it wrong. This talk cuts through the noise. Dr. Bednar will walk through all the major categories of Python visualization libraries, lay out practical criteria for evaluating them, and show real examples of what each type of tool can actually do. Whether you're exploring a messy dataset, building an interactive dashboard, or publishing a polished figure, there's a right tool for that - and probably a wrong one you're currently using because someone on your team grabbed it first. Stop inheriting other people's defaults, and come find yours!
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/KpmEVWWN1Aw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Dr. James A. Bednar**
 
 ![Dr. James A. Bednar Headshot](../assets/images/speakers/james.jpg){: width="150" align=left}
@@ -62,6 +70,8 @@ _Senior Director of Professional Services at Anaconda, Inc., founder of the Holo
 ## Why Installing Python Packages Is Still a Security Risk
 
 While it is widely known that there are risks in installing untrusted Python packages, the nature of those risks are often unclear. Back when installation required directly calling `setup.py` with `python`, the risks were obvious. Now, using wheels, `pip install`, and `pyproject.toml`, it is at least possible to install a package without running arbitrary code. Yet even with the best modern tools, there remain many ways arbitrary code can be run or planted on installation. This talk will introduce installation-time threats and practical defenses, relevant for anyone who installs packages or maintains production Python environments.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/6nBqP0pGT3k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Speaker: Christopher Ariza**
 
@@ -79,6 +89,8 @@ In this talk, we'll reveal the magic of how Python decides what happens when you
 
 You'll walk away with a clearer mental model of Python's object model, a few new "aha!" moments, and maybe the inspiration to build a descriptor or two yourself.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/NVKnYw4Z6B0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Scott Irwin**
 
 ![Scott Irwin Headshot](https://pretalx.com/media/avatars/EWKHZ9_I9FQTKU.webp){: width="150" align=left}
@@ -93,6 +105,8 @@ Let's say you are notified that a critical pipeline failed because a source file
 
 Data Engineering doesn't have to be a constant cycle of firefighting. By borrowing battle tested practices from traditional software engineering like strict type hinting, robust unit testing, and defensive design, we can build pipelines that are resilient by default. This talk is a survival guide for the modern Data Engineer. We will move beyond scripting and explore how to use standard Python tools (like Pydantic, pytest, and logging) to catch dirty data and logic errors in CI/CD, long before they wake you up.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/vllVi_pKd9M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Indrasena Manga**
 
 ![Indrasena Manga Headshot](../assets/images/speakers/Indrasena_Manga.png){: width="150" align=left}
@@ -105,6 +119,8 @@ _Indrasena Manga, a Senior Data Engineer at AXS.com (Texas, USA) with expertise 
 
 "AI is going to replace all software engineers if we could just get it to stop deleting the database." This talk explores the possibility of non-developers using AI to "vibe code" software, along with some hilarious failures. Circular mazes, lava lamp screensavers, virtual abacuses, combination lock simulators, and an African geography map quiz: Al Sweigart presents AI-generated Python code that doesn't quite reach success.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/01NuRv-LsH0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Al Sweigart**
 
 ![Al Sweigart Headshot](https://pretalx.com/media/avatars/HVAES8_0rorN3p.webp){: width="150" align=left}
@@ -116,6 +132,8 @@ _Al Sweigart (rhymes with "why dirt") is a software developer, tech book author,
 ## The Bakery: How PEP810 sped up my bread operations business
 
 Discover how PEP 810's explicit lazy imports can dramatically improve Python application startup times. Using a real CLI tool as a case study, that we totally use in our real business, this talk demonstrates practical techniques to optimize import performance while maintaining code clarity and safety.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/JplCNLBD5Dw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Speaker: Jacob Coffee**
 
@@ -130,6 +148,8 @@ _Jacob Coffee is an Infrastructure Engineer at the Python Software Foundation an
 Installation shouldn't be a barrier to learning Python. In this talk, you'll discover how to turn traditional documentation into fully interactive, zero-setup Python environments straight in your browser - no servers, containers, or local installation necessary. You'll learn how to use MkDocs + JupyterLite (via WebAssembly) to embed live code, auto-sync code examples from your repo without duplication, and make presentation of your training documentation easier to utilize.
 
 If you maintain docs, teach Python, build internal tools, or just want smoother developer experiences, you'll walk away knowing exactly how to choose and implement the right approach for your team or project while gaining a fresh appreciation for how accessible Python learning can be when we remove barriers.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/XNS3IwQZD80" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Speaker: Kassandra Keeton, the Prosperous Heart**
 
@@ -157,6 +177,8 @@ _Sumaiya Nalukwago is an experienced IT Professional currently working with Mbar
 
 Modern software applications are distributed systems. They need to connect and communicate with other applications across a network. Event-Driven Architecture is a common pattern for facilitating this connectivity, using Events as the communication abstraction. However, this pattern introduces complexities as well, such as fragmented logic, increased latency, decreased observability, and more. But what if there were a way to get the benefits of Event-Driven Architecture without the complexities?
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/r1YI5o5P8h8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Mason Egger**
 
 ![Mason Egger Headshot](https://github.com/masonegger.png){: width="150" align=left}
@@ -168,6 +190,8 @@ _Mason is currently a Senior Solutions Architect at Temporal Technologies, where
 ## Are API Tests Overrated? Let's Mitigate Risks in Smarter Ways
 
 API tests are often seen as essential, but are they always worth the effort? In this talk, we will challenge conventional testing strategies and explore whether API tests are truly the best way to catch meaningful bugs. We will consider smarter alternatives like unit testing handlers, contract testing, and well-placed UI tests — all through the lens of Domain-Driven Design. Rather than advocating for zero API tests, this is a call to be more deliberate about where and why we test. You'll leave with practical insights for building faster, more focused, and more maintainable test suites.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/3juU3JOIG3E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Speaker: Pandy Knight**
 
@@ -181,6 +205,8 @@ _Andrew Knight, also known as "Pandy," is the Automation Panda. He's a software 
 
 Observability is the cornerstone of our modern distributed systems - if your app has services, having an observable system is crucial. But what if we applied the same logic to living things? This talk introduces my python-coded virtual cat, Meow'py, and basic functions of OpenTelemetry with Elastic Observability. I will show the basic data flow of my app, give a quick code deep dive, and present a demo of Meow'py enjoying his habitat (AKA eating, pooping, attempting escapes..) as his observability stats fluctuate in our Kibana dashboard. Attendees will leave with a greater understanding of OpenTelemetry, and learn the benefits of implementing observability to the internet of things, living or not.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/r2X48XuvRT4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Sophia Solomon**
 
 ![Sophia Solomon Headshot](https://pretalx.com/media/avatars/XGSEGN_CSCncDP.webp){: width="150" align=left}
@@ -192,6 +218,8 @@ _Hello, my name is Sophia! With a background in Biochemistry from UT Austin, I d
 ## Tying Up Loose Threads: Making your Project No-GIL Ready
 
 If you, a project maintainer, want to support the free-threaded interpreter, but are unsure how, then this is for you! I'll show why ditching the GIL will yield extra performance, tips on making your compiled extensions compatible with the new ABI, and catching bugs as part of your automated workflows.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Z43-0VII3QA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Speaker: Charlie Lin**
 
@@ -207,6 +235,8 @@ Most Python command-line tools start simple: print statements, argument parsing,
 
 In this talk, we will show that we can do better than that, using libraries like Textual, Rich and Typer. We will cover the process to move from basic scripts into professional Terminal User Interfaces (TUIs) with interactive components, real-time updates and visual feedback. We will go over practical patterns for building tools that you can use for data processing, monitoring or config management.
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ZbAtJ4E9AGQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **Speaker: Avik Basu**
 
 ![Avik Basu Headshot](https://pretalx.com/media/avatars/Z7XLKH_Rey05Sy.webp){: width="150" align=left}
@@ -218,6 +248,8 @@ _Avik is a seasoned data scientist and software engineer passionate about writin
 ## Lint Fast, Type Hard: Elevate your code quality in Python with modern, ultra-fast tooling
 
 Modern Python tooling has turned code quality into a speed advantage. This talk shows how ultra-fast linters, formatters, and type checkers—like Ruff and Pyrefly—remove the usual friction and make best practices feel effortless. You'll learn how to introduce these tools across engineering teams without disruption, why performance drives adoption, and how to build a workflow where quality checks become the fastest part of your day.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/chfwQqqofdI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **Speaker: Miguel Vargas**
 

--- a/docs/schedule/talks.md
+++ b/docs/schedule/talks.md
@@ -11,29 +11,59 @@ Python's flexibility makes it an excellent choice for creating Domain-Specific L
 
 In this talk, we'll explore the art and science of designing Python DSLs that don't fight against the language's principles. You'll learn when to embrace Python's "magic" and when it becomes harmful, how to create APIs that feel pythonic even when they're domain-specific, and practical techniques for building DSLs through detailed analysis of successful real-world examples.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/K3JL5C8HFqo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/K3JL5C8HFqo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+</div>
 
 **Speaker: Moshe Zadka**
 
-![Moshe Zadka Headshot](https://pretalx.com/media/avatars/KYYQVJ_v0LCIik.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Moshe Zadka Headshot](https://pretalx.com/media/avatars/KYYQVJ_v0LCIik.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Moshe has been a DevOps/SRE since before those terms existed, caring deeply about software reliability, build reproducibility, and other such things. They have worked in companies as small as three people and as big as tens of thousands—usually someplace around where software meets system administration._
 
-<br clear=all>
+</div>
+</div>
 
 ## I Built an AI Running Coach (That Actually Remembers My Training)
 
 Generic fitness apps don't know when you're sick, stressed, or injured. In this talk, I'll show how I built a personal AI running coach using Python. You'll learn how to reverse-engineer undocumented APIs (like Peloton), handle conflicting data, and use async serverless patterns to give LLMs "memory" and context.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/EfIbH20J97Q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/EfIbH20J97Q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Adam's Resources**
+
+- [Repo](https://github.com/adamgordonbell/ai-running-coach https://www.pulumi.com/community/community-engineering/adam-gordon-bell/) (simplified version of what Adam's running)
+- His [site](https://www.pulumi.com/community/community-engineering/adam-gordon-bell/)
+
+</div>
+</div>
 
 **Speaker: Adam Gordon Bell**
 
-![Adam Gordon Bell Headshot](https://pretalx.com/media/avatars/GWK7YJ_1Hh3llG.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Adam Gordon Bell Headshot](https://pretalx.com/media/avatars/GWK7YJ_1Hh3llG.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Adam Gordon Bell is a software engineer and host of the CoRecursive podcast, where he interviews developers about the stories behind their code. He is known for his deep dives into system internals, including his popular work analyzing Python's Timsort merge logic. Currently, he is a Community Engineer at Pulumi, where he helps developers build infrastructure using the programming languages they already know. He works remotely from Canada and enjoys building overly complex Python automations for his daily life._
 
-<br clear=all>
+</div>
+</div>
 
 ## Using MCP to Build Safe, Auditable AI Systems in Python
 
@@ -43,43 +73,103 @@ The Model Context Protocol (MCP) offers a structured way to expose Python tools 
 
 We will show how to apply schema validation, introduce simple sandboxing rules, and log tool usage for transparency. The goal is to provide practical patterns that help developers build LLM-powered features in Python with more confidence and oversight.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/rYPl3Tp978Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/rYPl3Tp978Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Maria's Resources**
+
+- [Repo](https://github.com/MS-Mielnic/pytexas-mcp-demo)
+
+</div>
+</div>
 
 **Speaker: Maria Silvia Mielniczuk**
 
-![Maria Silvia Mielniczuk Headshot](../assets/images/speakers/Maria_Silvia_Mielniczuk.png){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Maria Silvia Mielniczuk Headshot](../assets/images/speakers/Maria_Silvia_Mielniczuk.png){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Maria Silvia Mielniczuk is a data scientist with a Master of Applied Data Science from the University of Michigan (2025). She works at Splunk, a Cisco company, helping customers in Brazil tackle big-data challenges in cybersecurity and observability across financial services, ecommerce, and healthcare. Originally from Argentina, she spent 17 years living in Brazil and Mexico before becoming a proud Texan. She's also happily married and the mother of three teenage boys — her true inspiration to run marathons._
 
-<br clear=all>
+</div>
+</div>
 
 ## Data Visualization in Python (Sponsored)
 
 With over 150 open-source visualization tools in the Python ecosystem, picking the right one can feel like choosing a restaurant in a city you've never visited - overwhelming, and with real consequences if you get it wrong. This talk cuts through the noise. Dr. Bednar will walk through all the major categories of Python visualization libraries, lay out practical criteria for evaluating them, and show real examples of what each type of tool can actually do. Whether you're exploring a messy dataset, building an interactive dashboard, or publishing a polished figure, there's a right tool for that - and probably a wrong one you're currently using because someone on your team grabbed it first. Stop inheriting other people's defaults, and come find yours!
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/KpmEVWWN1Aw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/KpmEVWWN1Aw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Resources**
+
+- [Presentation deck](https://tinyurl.com/pytexas26) (slides)
+
+</div>
+</div>
 
 **Speaker: Dr. James A. Bednar**
 
-![Dr. James A. Bednar Headshot](../assets/images/speakers/james.jpg){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Dr. James A. Bednar Headshot](../assets/images/speakers/james.jpg){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Senior Director of Professional Services at Anaconda, Inc., founder of the HoloViz project, and former Reader in Computational Neuroscience at U. Edinburgh._
 
-<br clear=all>
+</div>
+</div>
 
 ## Why Installing Python Packages Is Still a Security Risk
 
 While it is widely known that there are risks in installing untrusted Python packages, the nature of those risks are often unclear. Back when installation required directly calling `setup.py` with `python`, the risks were obvious. Now, using wheels, `pip install`, and `pyproject.toml`, it is at least possible to install a package without running arbitrary code. Yet even with the best modern tools, there remain many ways arbitrary code can be run or planted on installation. This talk will introduce installation-time threats and practical defenses, relevant for anyone who installs packages or maintains production Python environments.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/6nBqP0pGT3k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/6nBqP0pGT3k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Resources**
+
+- [libraries.io](https://libraries.io/)
+- [snyk](https://snyk.io/)
+- [pip-audit](https://github.com/pypa/pip-audit)
+- [dependabot](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart-guide) (There have been some exploits around dependabot recently - [here](https
+://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/) is a great way to consider some more security posturing)
+- [fetter.io](http://fetter.io)
+- [flexatone](https://www.flexatone.net)
+
+</div>
+</div>
 
 **Speaker: Christopher Ariza**
 
-![Christopher Ariza Headshot](https://pretalx.com/media/avatars/RGP8QS_KREo4xP.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Christopher Ariza Headshot](https://pretalx.com/media/avatars/RGP8QS_KREo4xP.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Christopher Ariza is Partner and Chief Technology Officer at Research Affiliates, a global leader in investment strategies and research. He is the creator of StaticFrame, an alternative Python DataFrame library that offers immutable and statically-typeable DataFrames. He is also the creator of Fetter, a Rust-implemented tool for system-wide Python package discovery, vulnerability auditing, and allow-list enforcement. Having worked in Python for over 25 years, he has developed tools in a variety of domains, writes on diverse technical topics, and has spoken at numerous conferences including PyCon USA, SciPy, PyBeach, and PyData._
 
-<br clear=all>
+</div>
+</div>
 
 ## Behind the Magic: Unlocking Python's Descriptor Protocol
 
@@ -89,15 +179,34 @@ In this talk, we'll reveal the magic of how Python decides what happens when you
 
 You'll walk away with a clearer mental model of Python's object model, a few new "aha!" moments, and maybe the inspiration to build a descriptor or two yourself.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/NVKnYw4Z6B0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/NVKnYw4Z6B0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Resources**
+
+- [Repo](https://github.com/sjirwin/behind-the-magic-slides)
+- Python [descriptor guide](https://docs.python.org/3/howto/descriptor.html)
+
+</div>
+</div>
 
 **Speaker: Scott Irwin**
 
-![Scott Irwin Headshot](https://pretalx.com/media/avatars/EWKHZ9_I9FQTKU.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Scott Irwin Headshot](https://pretalx.com/media/avatars/EWKHZ9_I9FQTKU.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _As a senior engineer at Bloomberg, Scott Irwin has spent more than a decade bridging engineering and education - building Python applications, leading development teams, and teaching hundreds of engineers through Bloomberg's internal training programs. He's passionate about helping developers write cleaner, more maintainable code. Beyond Bloomberg, Scott has taught Python to a broader audience through live online training events on the O'Reilly learning platform._
 
-<br clear=all>
+</div>
+</div>
 
 ## Data Engineer's survival guide: writing pipelines that don't break at 3 AM
 
@@ -105,43 +214,92 @@ Let's say you are notified that a critical pipeline failed because a source file
 
 Data Engineering doesn't have to be a constant cycle of firefighting. By borrowing battle tested practices from traditional software engineering like strict type hinting, robust unit testing, and defensive design, we can build pipelines that are resilient by default. This talk is a survival guide for the modern Data Engineer. We will move beyond scripting and explore how to use standard Python tools (like Pydantic, pytest, and logging) to catch dirty data and logic errors in CI/CD, long before they wake you up.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/vllVi_pKd9M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/vllVi_pKd9M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+</div>
 
-**Speaker: Indrasena Manga**
+**Speaker: [Indrasena Manga](https://www.linkedin.com/in/indra7979/)**
 
-![Indrasena Manga Headshot](../assets/images/speakers/Indrasena_Manga.png){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Indrasena Manga Headshot](../assets/images/speakers/Indrasena_Manga.png){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Indrasena Manga, a Senior Data Engineer at AXS.com (Texas, USA) with expertise in AI/ML systems, real-time data streaming, and large-scale data engineering. I've authored 10+ Scopus and IEEE indexed research papers, served as a Session Chair & Guest Speaker at IEEE ComputingCon-2025, served as a Session chair for GCAT-2025, and completed 30+ peer reviews for Elsevier, Springer, and IEEE. I'm a provisional patent holder (USPTO) for an AI-driven disaster relief system and an active member of IEEE, ACM (SIGAI, SIGKDD), and SCRS._
 
-<br clear=all>
+</div>
+</div>
 
 ## Failed Experiments in Vibe Coding
 
 "AI is going to replace all software engineers if we could just get it to stop deleting the database." This talk explores the possibility of non-developers using AI to "vibe code" software, along with some hilarious failures. Circular mazes, lava lamp screensavers, virtual abacuses, combination lock simulators, and an African geography map quiz: Al Sweigart presents AI-generated Python code that doesn't quite reach success.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/01NuRv-LsH0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/01NuRv-LsH0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Resources**
+
+- [Slides](https://docs.google.com/presentation/d/1kEWwytGKwSa12ZwMozxr_qsV75rM180E_omuxuR2SlM/edit?usp=sharing) (originally linked from [here](http://inventwithpython.com/pytexas2026))
+- ButtonPad [repo](https://github.com/asweigart/buttonpad)
+- Vibe Coding [experiment failures](https://inventwithpython.com/blog/vibe-coding-failures.html)
+
+</div>
+</div>
 
 **Speaker: Al Sweigart**
 
-![Al Sweigart Headshot](https://pretalx.com/media/avatars/HVAES8_0rorN3p.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Al Sweigart Headshot](https://pretalx.com/media/avatars/HVAES8_0rorN3p.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Al Sweigart (rhymes with "why dirt") is a software developer, tech book author, artist, and Fellow of the Python Software Foundation. His books include Automate the Boring Stuff with Python, The Recursive Book of Recursion, and The Big Book of Small Python Projects. He is the maintainer of several open source projects, including PyAutoGUI and pyperclip. He enjoys writing software, creating digital art, fostering cats, donating platelets, folding origami, and picking up litter._
 
-<br clear=all>
+</div>
+</div>
 
 ## The Bakery: How PEP810 sped up my bread operations business
 
 Discover how PEP 810's explicit lazy imports can dramatically improve Python application startup times. Using a real CLI tool as a case study, that we totally use in our real business, this talk demonstrates practical techniques to optimize import performance while maintaining code clarity and safety.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/JplCNLBD5Dw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/JplCNLBD5Dw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Resources**
+
+- [Repo](https://github.com/jacobcoffee/breadctl)
+
+</div>
+</div>
 
 **Speaker: Jacob Coffee**
 
-![Jacob Coffee Headshot](https://pretalx.com/media/avatars/S9XY8N_8FyIg6i.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Jacob Coffee Headshot](https://pretalx.com/media/avatars/S9XY8N_8FyIg6i.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Jacob Coffee is an Infrastructure Engineer at the Python Software Foundation and a newly invited CPython triager. He supports key Python services such as PyPI.org and Python.org while also contributing to the maintenance of the Litestar ecosystem which boasts libraries such as Litestar, Advanced Alchemy, Polyfactory, and more. He is passionate about open-source development, the mission of the PSF, and enhancing the tools that empower developers worldwide._
 
-<br clear=all>
+</div>
+</div>
 
 ## Python in the Browser: Building Interactive Documentation with MkDocs & JupyterLite
 
@@ -149,15 +307,33 @@ Installation shouldn't be a barrier to learning Python. In this talk, you'll dis
 
 If you maintain docs, teach Python, build internal tools, or just want smoother developer experiences, you'll walk away knowing exactly how to choose and implement the right approach for your team or project while gaining a fresh appreciation for how accessible Python learning can be when we remove barriers.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/XNS3IwQZD80" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/XNS3IwQZD80" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
 
-**Speaker: Kassandra Keeton, the Prosperous Heart**
+**Resources**
 
-![Kassandra Keeton Headshot](https://pretalx.com/media/avatars/TAGTJC_OCnUUcW.webp){: width="150" align=left}
+- mkdocs [Site](https://resume.prosperousheart.com/mkdocs-jupyterlite-template-repo/) (including embedded deck) for the template [repo](https://github.com/ProsperousHeart/mkdocs-jupyterlite-template-repo)
+
+</div>
+</div>
+
+**Speaker: [Kassandra Keeton](https://www.linkedin.com/in/kkeeton/), the Prosperous Heart**
+
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Kassandra Keeton Headshot](https://pretalx.com/media/avatars/TAGTJC_OCnUUcW.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Kassandra is currently a Customer Delivery Software Architect at Cisco Systems who is passionate about empowering others to create greater success in their lives. She does so by being a developer advocate, breaking down what she knows into easy-to-understand byte-sized pieces, and sharing her experiences in the hopes that others can achieve their desired outcomes faster. A budding gardener, she also enjoys finding ways to more efficiently utilize technology to support people and our planet._
 
-<br clear=all>
+</div>
+</div>
 
 ## Mastered development but still stuck? The hidden power of soft skills in your codebase.
 
@@ -167,67 +343,125 @@ This talk will delve into this often-overlooked reality, exploring why mastering
 
 **Speaker: Sumaiya Nalukwago**
 
-![Sumaiya Nalukwago Headshot](https://pretalx.com/media/avatars/YZWKNQ_xbBJ8Hj.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Sumaiya Nalukwago Headshot](https://pretalx.com/media/avatars/YZWKNQ_xbBJ8Hj.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Sumaiya Nalukwago is an experienced IT Professional currently working with Mbarara University of Science and Technology and Tech Community Lead with over six years of proven success in leveraging technology to drive economic development and nurture innovation across Uganda and beyond. As a Community Manager for Google Developer Groups Cloud Mbarara and an Ambassador for Google Women Techmakers (with Technovation), Sumaiya actively skills and mentors thousands of youth and women entrepreneurs in digital literacy, business development, and tech-solution design._
 
-<br clear=all>
+</div>
+</div>
 
 ## Events are the Wrong Abstraction (Sponsored)
 
 Modern software applications are distributed systems. They need to connect and communicate with other applications across a network. Event-Driven Architecture is a common pattern for facilitating this connectivity, using Events as the communication abstraction. However, this pattern introduces complexities as well, such as fragmented logic, increased latency, decreased observability, and more. But what if there were a way to get the benefits of Event-Driven Architecture without the complexities?
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/r1YI5o5P8h8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/r1YI5o5P8h8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Resources**
+
+- Play with the Durable Execution playground [here](https://t.mp/pytx2026) (it has instructions)
+
+</div>
+</div>
 
 **Speaker: Mason Egger**
 
-![Mason Egger Headshot](https://github.com/masonegger.png){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Mason Egger Headshot](https://github.com/masonegger.png){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Mason is currently a Senior Solutions Architect at Temporal Technologies, where he works with customers to architect and implement durable execution solutions. He specializes in Python, distributed systems, building community, and creating developer-focused educational content. He's an avid programmer, speaker, educator, and writer/blogger. He is President of the PyTexas Foundation, Conference Chair of the PyTexas Conference, and a founding organizer of the PyTexas Meetup. He was made a PSF Fellow in October 2025._
 
-<br clear=all>
+</div>
+</div>
 
 ## Are API Tests Overrated? Let's Mitigate Risks in Smarter Ways
 
 API tests are often seen as essential, but are they always worth the effort? In this talk, we will challenge conventional testing strategies and explore whether API tests are truly the best way to catch meaningful bugs. We will consider smarter alternatives like unit testing handlers, contract testing, and well-placed UI tests — all through the lens of Domain-Driven Design. Rather than advocating for zero API tests, this is a call to be more deliberate about where and why we test. You'll leave with practical insights for building faster, more focused, and more maintainable test suites.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/3juU3JOIG3E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/3juU3JOIG3E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+</div>
 
 **Speaker: Pandy Knight**
 
-![Pandy Knight Headshot](https://pretalx.com/media/avatars/8WV93W_PThO96W.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Pandy Knight Headshot](https://pretalx.com/media/avatars/8WV93W_PThO96W.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Andrew Knight, also known as "Pandy," is the Automation Panda. He's a software quality champion who loves to help people build better quality software. Currently, he works as the Senior Director of Product Management at Cycle Labs, focusing on building an excellent test automation platform for enterprise systems. Previously, Pandy spent a decade as a SDET building solutions to testing problems at various tech companies. He also previously led Developer Relations and Test Automation University at Applitools. Apart from software, Pandy spends time with his family, his French Bulldog, and his vintage Volkswagens._
 
-<br clear=all>
+</div>
+</div>
 
 ## Introducing Meow'py: Observability for the Internet of Living Things
 
 Observability is the cornerstone of our modern distributed systems - if your app has services, having an observable system is crucial. But what if we applied the same logic to living things? This talk introduces my python-coded virtual cat, Meow'py, and basic functions of OpenTelemetry with Elastic Observability. I will show the basic data flow of my app, give a quick code deep dive, and present a demo of Meow'py enjoying his habitat (AKA eating, pooping, attempting escapes..) as his observability stats fluctuate in our Kibana dashboard. Attendees will leave with a greater understanding of OpenTelemetry, and learn the benefits of implementing observability to the internet of things, living or not.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/r2X48XuvRT4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/r2X48XuvRT4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+</div>
 
 **Speaker: Sophia Solomon**
 
-![Sophia Solomon Headshot](https://pretalx.com/media/avatars/XGSEGN_CSCncDP.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Sophia Solomon Headshot](https://pretalx.com/media/avatars/XGSEGN_CSCncDP.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Hello, my name is Sophia! With a background in Biochemistry from UT Austin, I discovered a passion for coding in the DIY Diagnostics lab, where wet lab research and software development went hand in hand. After graduating in 2021, I began my career at GM as a Deployment Engineer/Analyst, later transitioning into a Software Engineering role observing real-time LLM based robotic systems on the plant floor. Now, as a Developer Advocate at Elastic, I draw on my experience optimizing and troubleshooting logs, traces, and metrics in high-stakes, in-plant production environments._
 
-<br clear=all>
+</div>
+</div>
 
 ## Tying Up Loose Threads: Making your Project No-GIL Ready
 
 If you, a project maintainer, want to support the free-threaded interpreter, but are unsure how, then this is for you! I'll show why ditching the GIL will yield extra performance, tips on making your compiled extensions compatible with the new ABI, and catching bugs as part of your automated workflows.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Z43-0VII3QA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/Z43-0VII3QA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+</div>
 
 **Speaker: Charlie Lin**
 
-![Charlie Lin Headshot](https://pretalx.com/media/avatars/CF8GNQ_bi6rPLz.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Charlie Lin Headshot](https://pretalx.com/media/avatars/CF8GNQ_bi6rPLz.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Fervent open-source enthusiast, and (self-inflicted) daily driver of bleeding edge pre-release software on both Linux and Windows._
 
-<br clear=all>
+</div>
+</div>
 
 ## Upgrading Python CLIs: From Scripts to Interactive Tools
 
@@ -235,26 +469,66 @@ Most Python command-line tools start simple: print statements, argument parsing,
 
 In this talk, we will show that we can do better than that, using libraries like Textual, Rich and Typer. We will cover the process to move from basic scripts into professional Terminal User Interfaces (TUIs) with interactive components, real-time updates and visual feedback. We will go over practical patterns for building tools that you can use for data processing, monitoring or config management.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ZbAtJ4E9AGQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/ZbAtJ4E9AGQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
 
-**Speaker: Avik Basu**
+**Resources**
 
-![Avik Basu Headshot](https://pretalx.com/media/avatars/Z7XLKH_Rey05Sy.webp){: width="150" align=left}
+- [Slides](https://github.com/ab93/building-cli-talk/blob/main/slides/slides.pdf)
+- [Repo](https://github.com/ab93/shap-monitor)
+
+
+</div>
+</div>
+
+**Speaker: [Avik Basu](https://www.linkedin.com/in/avik-basu/)**
+
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Avik Basu Headshot](https://pretalx.com/media/avatars/Z7XLKH_Rey05Sy.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Avik is a seasoned data scientist and software engineer passionate about writing elegant code and building intelligent systems that benefit humanity._
 
-<br clear=all>
+</div>
+</div>
 
 ## Lint Fast, Type Hard: Elevate your code quality in Python with modern, ultra-fast tooling
 
 Modern Python tooling has turned code quality into a speed advantage. This talk shows how ultra-fast linters, formatters, and type checkers—like Ruff and Pyrefly—remove the usual friction and make best practices feel effortless. You'll learn how to introduce these tools across engineering teams without disruption, why performance drives adoption, and how to build a workflow where quality checks become the fastest part of your day.
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/chfwQqqofdI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="speaker-video-section" markdown="1">
+<div class="video-wrapper">
+<iframe src="https://www.youtube-nocookie.com/embed/chfwQqqofdI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<div class="talk-links" markdown="1">
+
+**Resources**
+
+- [Slides](https://github.com/lmiguelvargasf/lint_fast_type_hard)
+- [pre-commit](https://pre-commit.com/)
+- [prek](https://prek.j178.dev)
+
+</div>
+</div>
 
 **Speaker: Miguel Vargas**
 
-![Miguel Vargas Headshot](https://pretalx.com/media/avatars/KBMPUQ_Kzd91NX.webp){: width="150" align=left}
+<div class="speaker-middle" markdown="1">
+<div markdown="1">
+
+![Miguel Vargas Headshot](https://pretalx.com/media/avatars/KBMPUQ_Kzd91NX.webp){: width="150"}
+
+</div>
+<div markdown="1">
 
 _Software engineer from Ecuador with over a decade of experience across healthcare, fintech, and real estate startups. I build with Python and TypeScript, focusing on Django, FastAPI, React, and Next.js. I'm driven by a deep interest in math, science, AI, and robotics._
 
-<br clear=all>
+</div>
+</div>

--- a/docs/schedule/talks.md
+++ b/docs/schedule/talks.md
@@ -44,7 +44,7 @@ Generic fitness apps don't know when you're sick, stressed, or injured. In this 
 
 **Adam's Resources**
 
-- [Repo](https://github.com/adamgordonbell/ai-running-coach https://www.pulumi.com/community/community-engineering/adam-gordon-bell/) (simplified version of what Adam's running)
+- [Repo](https://github.com/adamgordonbell/ai-running-coach) (simplified version of what Adam's running)
 - His [site](https://www.pulumi.com/community/community-engineering/adam-gordon-bell/)
 
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -488,3 +488,103 @@ figcaption>a:focus {
     background-color: var(--pytx-brown);
     color: var(--background-color);
 }
+
+/* ====================================
+   Keynote Card Formatting
+   ==================================== */
+
+.keynote-card {
+    margin: 1.5rem 0 2.5rem 0;
+}
+
+.keynote-middle {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+    align-items: start;
+}
+
+.keynote-middle img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.video-wrapper {
+    position: relative;
+    width: 100%;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+}
+
+.video-wrapper iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+@media (max-width: 600px) {
+    .keynote-middle {
+        display: block;
+    }
+
+    .keynote-middle img {
+        /* Copilot Suggestion */
+        width: 100px;
+        height: 100px;
+        margin-bottom: 0.5rem;
+    }
+}
+
+/* ====================================
+   Speaker Replay & Links Formatting
+   ==================================== */
+
+.speaker-card {
+    margin: 1.5rem 0 2.5rem 0;
+}
+
+.speaker-middle {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+    align-items: start;
+}
+
+.speaker-middle img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.speaker-video-section {
+    display: grid;
+    grid-template-columns: 1fr 200px;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.talk-links {
+    padding-top: 0.25rem;
+}
+
+@media (max-width: 768px) {
+    .speaker-middle {
+        display: block;
+    }
+    .speaker-middle img {
+        width: 150px;
+        margin-bottom: 0.75rem;
+    }
+    .speaker-video-section {
+        display: block;
+    }
+    .talk-links {
+        margin-top: 1rem;
+    }
+}


### PR DESCRIPTION
## Summary

Replicates the post-event pattern from the 2025 site (commit c1ab52b on the 2025 repo, "adding videos to site") by embedding each recording from the [PyTexas 2026 YouTube playlist](https://www.youtube.com/playlist?list=PL0MRiRrXAvRh0bfHGatkL10oI682zH0-F) directly on the schedule pages.

- Each `<iframe>` is placed under the talk description, immediately before the `**Speaker:**` block, matching the 2025 layout.
- Uses `youtube-nocookie.com/embed/<id>` (privacy-enhanced mode), same as 2025.
- Matches videos to talks by **speaker name** since several recording titles differ slightly from the original schedule titles (e.g. Mason Egger's recording is titled "Practical AI for Everyday Python Developers" rather than "Events are the Wrong Abstraction"). Each speaker has a unique session, so name-matching is unambiguous.

## Coverage

**Talks** (`docs/schedule/talks.md`) — 16 of 17 entries embedded:

| Speaker | Video |
| --- | --- |
| Moshe Zadka | K3JL5C8HFqo |
| Adam Gordon Bell | EfIbH20J97Q |
| Maria Silvia Mielniczuk | rYPl3Tp978Y |
| Dr. James A. Bednar | KpmEVWWN1Aw |
| Christopher Ariza | 6nBqP0pGT3k |
| Scott Irwin | NVKnYw4Z6B0 |
| Indrasena Manga | vllVi_pKd9M |
| Al Sweigart | 01NuRv-LsH0 |
| Jacob Coffee | JplCNLBD5Dw |
| Kassandra Keeton | XNS3IwQZD80 |
| Mason Egger | r1YI5o5P8h8 |
| Pandy Knight | 3juU3JOIG3E |
| Sophia Solomon | r2X48XuvRT4 |
| Charlie Lin | Z43-0VII3QA |
| Avik Basu | ZbAtJ4E9AGQ |
| Miguel Vargas | chfwQqqofdI |

**Keynotes** (`docs/schedule/keynotes.md`):

| Speaker | Video |
| --- | --- |
| Dawn Wages (Day 1) | mHG3aAkbpvA |
| Hynek Schlawack (Day 2) | MDqQTtjbVX8 |

## Not embedded

- **Sumaiya Nalukwago** ("Mastered development but still stuck?") — no recording in the published playlist.
- **Patty Chow** ("Using Python for Good") — recording is in the playlist but the talk is not listed in `talks.md`. If it should be added, that's a separate edit.
- **Day 1 and Day 2 Lightning Talks** — playlist contains both recordings, but `talks.md` / `keynotes.md` have no lightning-talks section. The 2025 archive likewise omitted lightning talks from the schedule pages.

## Test plan

- [ ] `uv run mkdocs build --strict` passes
- [ ] `just serve` and spot-check that each iframe renders and points at the right video
- [ ] Verify Sumaiya Nalukwago's section looks intentional without an embed (no broken layout)